### PR TITLE
Remove dead code

### DIFF
--- a/src/qbindiff/loader/basic_block.py
+++ b/src/qbindiff/loader/basic_block.py
@@ -4,7 +4,6 @@ from functools import cached_property
 
 from qbindiff.loader.backend import AbstractBasicBlockBackend
 from qbindiff.loader import Instruction
-from qbindiff.loader.types import LoaderType
 from qbindiff.types import Addr
 from typing import List
 

--- a/src/qbindiff/loader/function.py
+++ b/src/qbindiff/loader/function.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Generator
 from typing import Set, List, Tuple
 
 from qbindiff.loader import BasicBlock
-from qbindiff.loader.types import LoaderType, FunctionType
+from qbindiff.loader.types import FunctionType
 from qbindiff.types import Addr
 from qbindiff.loader.backend.abstract import AbstractFunctionBackend
 

--- a/src/qbindiff/loader/instruction.py
+++ b/src/qbindiff/loader/instruction.py
@@ -3,7 +3,7 @@ from functools import cached_property
 
 from qbindiff.loader.backend import AbstractInstructionBackend
 from qbindiff.loader import Data, Operand
-from qbindiff.loader.types import LoaderType, ReferenceType, ReferenceTarget
+from qbindiff.loader.types import ReferenceType, ReferenceTarget
 from qbindiff.types import Addr
 from typing import List, Dict
 

--- a/src/qbindiff/loader/operand.py
+++ b/src/qbindiff/loader/operand.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from qbindiff.loader.backend import AbstractOperandBackend
-from qbindiff.loader.types import LoaderType
 
 
 class Operand:


### PR DESCRIPTION
Remove the old way of instantiating `Function`, `BasicBlock`, `Instruction`, `Operand` objects.
The new way of doing this is directly from an already instantiated backend