### PR TITLE
Make static typing PEP-585 compliant

### DIFF
--- a/src/qbindiff/abstract.py
+++ b/src/qbindiff/abstract.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterator
-from typing import Any, Tuple
+from typing import Any
 
 
 class GenericGraph(metaclass=ABCMeta):
@@ -25,7 +25,7 @@ class GenericGraph(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def items(self) -> Iterator[Tuple[Any, Any]]:
+    def items(self) -> Iterator[tuple[Any, Any]]:
         """
         Return an iterator over the items. Each item is {node_label: node}
         """
@@ -56,7 +56,7 @@ class GenericGraph(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def edges(self) -> Iterator[Tuple[Any, Any]]:
+    def edges(self) -> Iterator[tuple[Any, Any]]:
         """
         Return an iterator over the edges.
         An edge is a pair (node_label_a, node_label_b)

--- a/src/qbindiff/differ.py
+++ b/src/qbindiff/differ.py
@@ -20,8 +20,8 @@ import tqdm
 import numpy as np
 from datasketch import MinHash
 from networkx import DiGraph
-from collections.abc import Generator, Iterator
-from typing import Any, Callable, Optional, List, Type, Tuple, Dict
+from collections.abc import Generator, Iterator, Callable
+from typing import Any
 
 # third-party imports
 from bindiff import BindiffFile
@@ -91,8 +91,8 @@ class Differ:
         self.primary = primary
         #: Secondary graph
         self.secondary = secondary
-        self._pre_passes: List = []
-        self._post_passes: List = []
+        self._pre_passes: list = []
+        self._post_passes: list = []
         self._already_processed: bool = False  # Flag to perform the processing only once
 
         if normalize:
@@ -122,7 +122,7 @@ class Differ:
         self.p_features = None
         self.s_features = None
 
-    def get_similarities(self, primary_idx: List[Idx], secondary_idx: List[Idx]) -> List[float]:
+    def get_similarities(self, primary_idx: list[Idx], secondary_idx: list[Idx]) -> list[float]:
         """
         Returns the similarity scores between the nodes specified as parameter.
         By default, it uses the similarity matrix.
@@ -135,7 +135,7 @@ class Differ:
         """
         return self.sim_matrix[primary_idx, secondary_idx]
 
-    def _convert_mapping(self, mapping: RawMapping, confidence: List[float]) -> Mapping:
+    def _convert_mapping(self, mapping: RawMapping, confidence: list[float]) -> Mapping:
         """
         Return the result of the diffing as a Mapping object.
 
@@ -188,7 +188,7 @@ class Differ:
 
     def extract_adjacency_matrix(
         self, graph: Graph
-    ) -> (AdjacencyMatrix, Dict[Addr, Idx], Dict[Idx, Addr]):
+    ) -> (AdjacencyMatrix, dict[Addr, Idx], dict[Idx, Addr]):
         """
         Returns the adjacency matrix for the graph and the mappings
 
@@ -339,7 +339,7 @@ class DiGraphDiffer(Differ):
             """
             self._graph = graph
 
-        def items(self) -> Iterator[Tuple[Addr, Any]]:
+        def items(self) -> Iterator[tuple[Addr, Any]]:
             """
             Return an iterator over the items. Each item is {node_label: node}
             """
@@ -367,7 +367,7 @@ class DiGraphDiffer(Differ):
             return self._graph.nodes
 
         @property
-        def edges(self) -> Iterator[Tuple[Any, Any]]:
+        def edges(self) -> Iterator[tuple[Any, Any]]:
             """
             Return an iterator over the edges.
             An edge is a pair (node_label_a, node_label_b)
@@ -445,8 +445,8 @@ class QBinDiff(Differ):
         sim_matrix: SimMatrix,
         primary: Program,
         secondary: Program,
-        primary_mapping: Dict,
-        secondary_mapping: Dict,
+        primary_mapping: dict,
+        secondary_mapping: dict,
     ) -> None:
         """
         Anchoring phase. This phase considers import functions as anchors to the matching and set these functions
@@ -496,7 +496,7 @@ class QBinDiff(Differ):
 
         return program
 
-    def get_similarities(self, primary_idx: List[int], secondary_idx: List[int]) -> List[float]:
+    def get_similarities(self, primary_idx: list[int], secondary_idx: list[int]) -> list[float]:
         """
         Returns the similarity scores between the nodes specified as parameter.
         Uses MinHash fuzzy hash at basic block level to give a similarity score.

--- a/src/qbindiff/features/artefact.py
+++ b/src/qbindiff/features/artefact.py
@@ -16,7 +16,8 @@ limitations under the License.
 
 import re
 import random
-from typing import Optional, Any, Pattern
+from typing import Any
+from re import Pattern
 
 from qbindiff.features.extractor import (
     FeatureCollector,
@@ -123,7 +124,7 @@ class FuncName(FunctionFeatureExtractor):
 
     key = "fname"
 
-    def __init__(self, *args: Any, excluded_regex: Optional[Pattern[str]] = None, **kwargs: Any):
+    def __init__(self, *args: Any, excluded_regex: Pattern[str] | None = None, **kwargs: Any):
         """
         :param args: parameters of a feature extractor
         :param excluded_regex: regex to apply in order to exclude names

--- a/src/qbindiff/features/extractor.py
+++ b/src/qbindiff/features/extractor.py
@@ -14,10 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from dataclasses import dataclass
 from scipy.sparse import lil_array
 from collections import defaultdict
-from typing import Any, Callable, TypeVar, Dict, List, Set
 
 from qbindiff.features.manager import FeatureKeyManager
 from qbindiff.loader import Program, Function, BasicBlock, Instruction, Operand
@@ -34,7 +32,7 @@ class FeatureCollector:
     """
 
     def __init__(self):
-        self._features: Dict[str, FeatureValue] = {}
+        self._features: dict[str, FeatureValue] = {}
 
     def add_feature(self, key: str, value: float) -> None:
         """
@@ -48,7 +46,7 @@ class FeatureCollector:
         self._features.setdefault(key, 0)
         self._features[key] += value
 
-    def add_dict_feature(self, key: str, value: Dict[str, float]) -> None:
+    def add_dict_feature(self, key: str, value: dict[str, float]) -> None:
         """
         Add a feature value in the collector if the value is a dictionary of string to float.
 
@@ -72,7 +70,7 @@ class FeatureCollector:
             feature_vector[main_key] = feature
         return feature_vector
 
-    def full_keys(self) -> Dict[str, Set[str]]:
+    def full_keys(self) -> dict[str, set[str]]:
         """
         Returns a dict in which keys are the keys of the features and values are the subkeys.
         If a Feature directly maps to a float value, the set will be empty.
@@ -89,7 +87,7 @@ class FeatureCollector:
 
         return keys
 
-    def to_sparse_vector(self, dtype: type, main_key_list: List[str]) -> SparseVector:
+    def to_sparse_vector(self, dtype: type, main_key_list: list[str]) -> SparseVector:
         """
         Transform the collection to a sparse feature vector.
 
@@ -108,7 +106,7 @@ class FeatureCollector:
                 offset += manager.get_size(main_key)
                 continue
 
-            if isinstance(self._features[main_key], Dict):  # with subkeys
+            if isinstance(self._features[main_key], dict):  # with subkeys
                 for subkey, value in self._features[main_key].items():
                     vector[0, offset + manager.get(main_key, subkey)] = value
             else:  # without subkeys

--- a/src/qbindiff/features/graph.py
+++ b/src/qbindiff/features/graph.py
@@ -25,7 +25,6 @@ from qbindiff.features.extractor import (
 )
 from qbindiff.loader import Program, Function, Instruction, Operand
 from qbindiff.loader.types import OperandType
-from typing import List
 import hashlib
 import community
 
@@ -169,7 +168,7 @@ class SmallPrimeNumbers(FunctionFeatureExtractor):
     key = "spp"
 
     @staticmethod
-    def primesbelow(n: int) -> List[int]:
+    def primesbelow(n: int) -> list[int]:
         """
         Utility function that returns a list of all the primes below n.
         This comes from `Diaphora <https://github.com/joxeankoret/diaphora/blob/master/jkutils/factor.py>`_

--- a/src/qbindiff/features/manager.py
+++ b/src/qbindiff/features/manager.py
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import List
-
-
 class FeatureKeyManagerClass:
     """
     Singleton class that assigns a unique number to each main_key/sub_key.
@@ -47,7 +44,7 @@ class FeatureKeyManagerClass:
         else:
             return self.mainkeys[main_key]
 
-    def get_cumulative_size(self, main_key_list: List[str]) -> int:
+    def get_cumulative_size(self, main_key_list: list[str]) -> int:
         """
         Returns the cumulative size of all the main_keys
         """

--- a/src/qbindiff/features/wlgk.py
+++ b/src/qbindiff/features/wlgk.py
@@ -18,7 +18,6 @@ import random
 from functools import cache
 from collections import defaultdict, Counter
 from abc import ABCMeta, abstractmethod
-from typing import Optional
 
 from qbindiff.features.extractor import FunctionFeatureExtractor, FeatureCollector
 from qbindiff.loader import Program, Function, BasicBlock
@@ -58,7 +57,7 @@ class BOWLSH(LSH):
     Extract the bag-of-words representation of a block. The hashes are 4 bytes long.
     """
 
-    def __init__(self, node: Optional[BasicBlock] = None):
+    def __init__(self, node: BasicBlock | None = None):
         self.bag = defaultdict(int)
         if node is not None:
             for instr in node:

--- a/src/qbindiff/loader/backend/abstract.py
+++ b/src/qbindiff/loader/backend/abstract.py
@@ -21,7 +21,6 @@ from collections.abc import Iterator
 from qbindiff.loader import Structure
 from qbindiff.loader.types import FunctionType, ReferenceType, ReferenceTarget, OperandType
 from qbindiff.types import Addr
-from typing import Set, Dict, List
 
 
 class AbstractOperandBackend(metaclass=ABCMeta):
@@ -88,7 +87,7 @@ class AbstractInstructionBackend(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def references(self) -> Dict[ReferenceType, List[ReferenceTarget]]:
+    def references(self) -> dict[ReferenceType, list[ReferenceTarget]]:
         """
         Returns all the references towards the instruction
         """
@@ -104,7 +103,7 @@ class AbstractInstructionBackend(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def groups(self) -> List[str]:
+    def groups(self) -> list[str]:
         """
         Returns a list of groups of this instruction
         """
@@ -210,7 +209,7 @@ class AbstractFunctionBackend(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def parents(self) -> Set[Addr]:
+    def parents(self) -> set[Addr]:
         """
         Set of function parents in the call graph.
         """
@@ -218,7 +217,7 @@ class AbstractFunctionBackend(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def children(self) -> Set[Addr]:
+    def children(self) -> set[Addr]:
         """
         Set of function children in the call graph.
         """
@@ -271,7 +270,7 @@ class AbstractProgramBackend(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def structures(self) -> List[Structure]:
+    def structures(self) -> list[Structure]:
         """
         Returns the list of structures defined in program.
         """
@@ -287,7 +286,7 @@ class AbstractProgramBackend(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def fun_names(self) -> Dict[str, Addr]:
+    def fun_names(self) -> dict[str, Addr]:
         """
         Returns a dictionary with function name as key and the function address as value.
         """

--- a/src/qbindiff/loader/backend/binexport.py
+++ b/src/qbindiff/loader/backend/binexport.py
@@ -18,7 +18,7 @@ limitations under the License.
 from __future__ import annotations
 import logging
 import weakref
-from typing import Any, TypeAlias, Dict, List, Set
+from typing import Any, TypeAlias
 from collections.abc import Iterator
 from functools import cached_property
 
@@ -43,7 +43,6 @@ from qbindiff.types import Addr
 # Type aliases
 beFunction: TypeAlias = binexport.function.FunctionBinExport
 beBasicBlock: TypeAlias = binexport.basic_block.BasicBlockBinExport
-beInstruction: TypeAlias = binexport.instruction.InstructionBinExport
 capstoneOperand: TypeAlias = Any  # Relaxed typing
 
 
@@ -165,7 +164,7 @@ class InstructionBackendBinExport(AbstractInstructionBackend):
         return self.cs_instr.mnemonic
 
     @property
-    def references(self) -> Dict[ReferenceType, List[ReferenceTarget]]:
+    def references(self) -> dict[ReferenceType, list[ReferenceTarget]]:
         """
         Returns all the references towards the instruction
         BinExport only exports data references' address so no data type nor value.
@@ -183,7 +182,7 @@ class InstructionBackendBinExport(AbstractInstructionBackend):
         )
 
     @property
-    def groups(self) -> List[str]:
+    def groups(self) -> list[str]:
         return self.cs_instr.groups
 
     @property
@@ -323,12 +322,12 @@ class FunctionBackendBinExport(AbstractFunctionBackend):
         return self.be_func.graph
 
     @property
-    def parents(self) -> Set[Addr]:
+    def parents(self) -> set[Addr]:
         """Set of function parents in the call graph"""
         return {func.addr for func in self.be_func.parents}
 
     @property
-    def children(self) -> Set[Addr]:
+    def children(self) -> set[Addr]:
         """Set of function children in the call graph"""
         return {func.addr for func in self.be_func.children}
 
@@ -399,7 +398,7 @@ class ProgramBackendBinExport(AbstractProgramBackend):
         return self.be_prog.name
 
     @property
-    def structures(self) -> List[Structure]:
+    def structures(self) -> list[Structure]:
         """
         Returns the list of structures defined in program.
         WARNING: Not supported by BinExport
@@ -412,7 +411,7 @@ class ProgramBackendBinExport(AbstractProgramBackend):
         return self.be_prog.callgraph
 
     @property
-    def fun_names(self) -> Dict[str, int]:
+    def fun_names(self) -> dict[str, int]:
         """
         Returns a dictionary with function name as key and the function address as value
         """

--- a/src/qbindiff/loader/backend/quokka.py
+++ b/src/qbindiff/loader/backend/quokka.py
@@ -20,7 +20,7 @@ import logging
 import weakref
 from functools import cached_property
 from collections.abc import Iterator
-from typing import Any, TypeAlias, Set, Dict, List
+from typing import Any, TypeAlias
 
 # third party imports
 import quokka
@@ -51,7 +51,6 @@ from qbindiff.types import Addr
 
 # Aliases
 capstoneOperand: TypeAlias = Any  # Relaxed typing
-capstoneValue: TypeAlias = Any  # Relaxed typing
 
 
 # ===== General purpose utils functions =====
@@ -219,8 +218,8 @@ class InstructionBackendQuokka(AbstractInstructionBackend):
         block._raw_dict[self.qb_instr.address] = self.qb_instr.proto_index
 
     def _cast_references(
-        self, references: List[quokka.types.ReferenceTarget]
-    ) -> List[ReferenceTarget]:
+        self, references: list[quokka.types.ReferenceTarget]
+    ) -> list[ReferenceTarget]:
         """
         Cast the quokka references to qbindiff reference types
 
@@ -259,7 +258,7 @@ class InstructionBackendQuokka(AbstractInstructionBackend):
         return self.qb_instr.mnemonic
 
     @cached_property
-    def references(self) -> Dict[ReferenceType, List[ReferenceTarget]]:
+    def references(self) -> dict[ReferenceType, list[ReferenceTarget]]:
         """
         Returns all the references towards the instruction
 
@@ -286,7 +285,7 @@ class InstructionBackendQuokka(AbstractInstructionBackend):
         )
 
     @property
-    def groups(self) -> List[str]:
+    def groups(self) -> list[str]:
         """
         Returns a list of groups of this instruction. Groups are capstone based but enriched.
         """
@@ -420,7 +419,7 @@ class FunctionBackendQuokka(AbstractFunctionBackend):
         return self.qb_func.graph
 
     @cached_property
-    def parents(self) -> Set[Addr]:
+    def parents(self) -> set[Addr]:
         """
         Set of function parents in the call graph
         """
@@ -434,7 +433,7 @@ class FunctionBackendQuokka(AbstractFunctionBackend):
         return parents
 
     @cached_property
-    def children(self) -> Set[Addr]:
+    def children(self) -> set[Addr]:
         """
         Set of function children in the call graph
         """
@@ -531,7 +530,7 @@ class ProgramBackendQuokka(AbstractProgramBackend):
         return self.qb_prog.executable.exec_file.name
 
     @cached_property
-    def structures(self) -> List[Structure]:
+    def structures(self) -> list[Structure]:
         """Returns the list of structures defined in program"""
 
         struct_list = []
@@ -551,7 +550,7 @@ class ProgramBackendQuokka(AbstractProgramBackend):
         return struct_list
 
     @cached_property
-    def structures_by_name(self) -> Dict[str, Structure]:
+    def structures_by_name(self) -> dict[str, Structure]:
         """
         Returns the dictionary {name: structure}
         """
@@ -575,7 +574,7 @@ class ProgramBackendQuokka(AbstractProgramBackend):
         return self._callgraph
 
     @property
-    def fun_names(self) -> Dict[str, int]:
+    def fun_names(self) -> dict[str, int]:
         """
         Returns a dictionary with function name as key and the function address as value
         """

--- a/src/qbindiff/loader/basic_block.py
+++ b/src/qbindiff/loader/basic_block.py
@@ -21,7 +21,6 @@ from functools import cached_property
 from qbindiff.loader.backend import AbstractBasicBlockBackend
 from qbindiff.loader import Instruction
 from qbindiff.types import Addr
-from typing import List
 
 
 class BasicBlock(Iterable[Instruction]):
@@ -59,7 +58,7 @@ class BasicBlock(Iterable[Instruction]):
         return self._backend.addr
 
     @cached_property
-    def instructions(self) -> List[Instruction]:
+    def instructions(self) -> list[Instruction]:
         """
         List of Instruction objects of the basic block
         """

--- a/src/qbindiff/loader/function.py
+++ b/src/qbindiff/loader/function.py
@@ -17,7 +17,6 @@ limitations under the License.
 from __future__ import annotations
 import networkx
 from collections.abc import Mapping, Generator
-from typing import Set, List, Tuple
 
 from qbindiff.loader import BasicBlock
 from qbindiff.loader.types import FunctionType
@@ -152,7 +151,7 @@ class Function(Mapping[Addr, BasicBlock]):
             self._backend.unload_blocks()
 
     @property
-    def edges(self) -> List[Tuple[Addr, Addr]]:
+    def edges(self) -> list[tuple[Addr, Addr]]:
         """
         Edges of the function flowgraph as a list of tuples with basic block addresses
         """
@@ -177,7 +176,7 @@ class Function(Mapping[Addr, BasicBlock]):
         return self._backend.graph
 
     @property
-    def parents(self) -> Set[Addr]:
+    def parents(self) -> set[Addr]:
         """
         Set of function parents in the call graph.
         Thus functions that calls this function
@@ -186,7 +185,7 @@ class Function(Mapping[Addr, BasicBlock]):
         return self._backend.parents
 
     @property
-    def children(self) -> Set[Addr]:
+    def children(self) -> set[Addr]:
         """
         Set of functions called by this function in the call graph.
         """

--- a/src/qbindiff/loader/instruction.py
+++ b/src/qbindiff/loader/instruction.py
@@ -21,7 +21,6 @@ from qbindiff.loader.backend import AbstractInstructionBackend
 from qbindiff.loader import Data, Operand
 from qbindiff.loader.types import ReferenceType, ReferenceTarget
 from qbindiff.types import Addr
-from typing import List, Dict
 
 
 class Instruction:
@@ -57,7 +56,7 @@ class Instruction:
         return self._backend.mnemonic
 
     @cached_property
-    def references(self) -> Dict[ReferenceType, List[ReferenceTarget]]:
+    def references(self) -> dict[ReferenceType, list[ReferenceTarget]]:
         """
         Returns all the references towards the instruction
         """
@@ -65,7 +64,7 @@ class Instruction:
         return self._backend.references
 
     @property
-    def data_references(self) -> List[Data]:
+    def data_references(self) -> list[Data]:
         """
         Returns the list of data that are referenced by the instruction
 
@@ -79,7 +78,7 @@ class Instruction:
             return []
 
     @cached_property
-    def operands(self) -> List[Operand]:
+    def operands(self) -> list[Operand]:
         """
         Returns the list of operands as Operand object.
         """
@@ -87,7 +86,7 @@ class Instruction:
         return [Operand.from_backend(o) for o in self._backend.operands]
 
     @property
-    def groups(self) -> List[int]:
+    def groups(self) -> list[int]:
         """
         Returns a list of groups of this instruction.
         """

--- a/src/qbindiff/loader/program.py
+++ b/src/qbindiff/loader/program.py
@@ -16,8 +16,7 @@ limitations under the License.
 
 from __future__ import annotations
 import networkx
-from typing import Callable, Tuple, Dict, List
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 from qbindiff.abstract import GenericGraph
 from qbindiff.loader import Function, Structure
@@ -172,7 +171,7 @@ class Program(dict, GenericGraph):
         yield from self.__iter__()
 
     @property
-    def edges(self) -> Iterator[Tuple[Addr, Addr]]:
+    def edges(self) -> Iterator[tuple[Addr, Addr]]:
         """
         Iterator over the edges.
         An edge is a pair (addr_a, addr_b)
@@ -189,7 +188,7 @@ class Program(dict, GenericGraph):
         return self._backend.name
 
     @property
-    def structures(self) -> List[Structure]:
+    def structures(self) -> list[Structure]:
         """
         Returns the list of structures defined in program
         """

--- a/src/qbindiff/loader/structure.py
+++ b/src/qbindiff/loader/structure.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any
 
 from qbindiff.loader.types import DataType, StructureType
 
@@ -49,7 +49,7 @@ class Structure:
         self.type = struct_type
         self.name = name
         self.size = size
-        self.members: Dict[int, StructureMember] = {}  # { offset: StructureMember }
+        self.members: dict[int, StructureMember] = {}  # { offset: StructureMember }
 
     def add_member(
         self, offset: int, data_type: DataType, name: str, size: int, value: Any

--- a/src/qbindiff/mapping/bindiff.py
+++ b/src/qbindiff/mapping/bindiff.py
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from collections.abc import Generator
 from collections import defaultdict
+from collections.abc import Generator
 from functools import lru_cache
-from typing import List, Tuple
 
 # third-party imports
 from bindiff import BindiffFile
@@ -31,7 +30,7 @@ from qbindiff.types import Addr
 
 
 @lru_cache
-def primes() -> List[int]:
+def primes() -> list[int]:
     """
     The primes up to 1'000'000 using the segmented sieve algorithm
     """
@@ -87,7 +86,7 @@ def _compute_bb_prime_product(basic_block: BasicBlock) -> int:
 
 def compute_basic_block_match(
     primary_func: Function, secondary_func: Function
-) -> Generator[Tuple[Addr, Addr]]:
+) -> Generator[tuple[Addr, Addr]]:
     """
     Matches the basic blocks between the two functions
 
@@ -116,7 +115,7 @@ def compute_basic_block_match(
 
 def compute_instruction_match(
     primary_bb: BasicBlock, secondary_bb: BasicBlock
-) -> Generator[Tuple[Addr, Addr]]:
+) -> Generator[tuple[Addr, Addr]]:
     """
     Matches the instructions between the two basic blocks
 
@@ -149,7 +148,7 @@ def export_to_bindiff(
     """
     from qbindiff import VERSION  # import the version here to avoid circular definition
 
-    def count_items(program: Program) -> Tuple[int, int, int, int]:
+    def count_items(program: Program) -> tuple[int, int, int, int]:
         fp, flib, bbs, inst = 0, 0, 0, 0
         for f_addr, f in program.items():
             fp += int(not (f.is_import()))

--- a/src/qbindiff/mapping/mapping.py
+++ b/src/qbindiff/mapping/mapping.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional, Set
-
 from qbindiff.types import Match, ExtendedMapping, Item
 
 
@@ -86,28 +84,28 @@ class Mapping:
         self._matches.remove(match)
 
     @property
-    def primary_matched(self) -> Set[Item]:
+    def primary_matched(self) -> set[Item]:
         """
         Set of items matched in primary
         """
         return {x.primary for x in self._matches}
 
     @property
-    def primary_unmatched(self) -> Set[Item]:
+    def primary_unmatched(self) -> set[Item]:
         """
         Set of items unmatched in primary.
         """
         return self._primary_unmatched
 
     @property
-    def secondary_matched(self) -> Set[Item]:
+    def secondary_matched(self) -> set[Item]:
         """
         Set of items matched in the secondary object.
         """
         return {x.secondary for x in self._matches}
 
     @property
-    def secondary_unmatched(self) -> Set[Item]:
+    def secondary_unmatched(self) -> set[Item]:
         """
         Set of items unmatched in the secondary object.
         """
@@ -148,7 +146,7 @@ class Mapping:
         """
         return self.nb_match + self.nb_unmatched_secondary
 
-    def match_primary(self, item: Item) -> Optional[Match]:
+    def match_primary(self, item: Item) -> Match | None:
         """
         Returns the match associated with the given primary item (if any).
 
@@ -160,7 +158,7 @@ class Mapping:
                 return m
         return None
 
-    def match_secondary(self, item: Item) -> Optional[Match]:
+    def match_secondary(self, item: Item) -> Match | None:
         """
         Returns the match associated with the given secondary item (if any).
 

--- a/src/qbindiff/matcher/belief_propagation.py
+++ b/src/qbindiff/matcher/belief_propagation.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 import math
 import numpy as np
-from typing import Any, List
+from typing import Any
 from collections.abc import Generator
 
 # local imports
@@ -40,7 +40,7 @@ class BeliefMWM:
 
         self._init_messages()
 
-        self.scores: List[float] = []  #: Scores list
+        self.scores: list[float] = []  #: Scores list
         self.max_avg_score: float = 0.0  #: Current maximum average score
         self.best_mapping: RawMapping = None  #: Current best mapping
         self.best_marginals = None  #: Current associated marginals as a SparseMatrix

--- a/src/qbindiff/matcher/matcher.py
+++ b/src/qbindiff/matcher/matcher.py
@@ -22,7 +22,6 @@ import numpy as np
 from lapjv import lapjv
 from scipy.sparse import csr_matrix, coo_matrix
 from collections.abc import Generator
-from typing import Tuple, List
 
 # Local imports
 from qbindiff.matcher.squares import find_squares
@@ -38,7 +37,7 @@ from qbindiff.types import (
 )
 
 
-def iter_csr_matrix(matrix: SparseMatrix) -> Generator[Tuple[np.ndarray, np.ndarray]]:
+def iter_csr_matrix(matrix: SparseMatrix) -> Generator[tuple[np.ndarray, np.ndarray]]:
     """
     Iter over non-null items in a CSR (Compressed Sparse Row) matrix.
     It returns a generator that, at each iteration, returns the tuple (row_index, column_index, value)
@@ -213,7 +212,7 @@ class Matcher:
         return self._mapping
 
     @property
-    def confidence_score(self) -> List[float]:
+    def confidence_score(self) -> list[float]:
         """
         Confidence score for each match in the nodes mapping
         """

--- a/src/qbindiff/passes/base.py
+++ b/src/qbindiff/passes/base.py
@@ -19,8 +19,9 @@ import tqdm
 import numpy as np
 from scipy.sparse import lil_matrix
 from collections import defaultdict
+from collections.abc import Iterable
 from abc import ABCMeta, abstractmethod
-from typing import Any, Iterable, Dict, List, Tuple
+from typing import Any
 
 from qbindiff.loader import Program
 from qbindiff.visitor import ProgramVisitor
@@ -40,8 +41,8 @@ class GenericPass(metaclass=ABCMeta):
         sim_matrix: SimMatrix,
         primary: Program,
         secondary: Program,
-        primary_mapping: Dict[Any, int],
-        secondary_mapping: Dict[Any, int],
+        primary_mapping: dict[Any, int],
+        secondary_mapping: dict[Any, int],
     ) -> None:
         """Execute the pass that operates on the similarity matrix inplace"""
         raise NotImplementedError()
@@ -78,10 +79,10 @@ class FeaturePass(GenericPass):
 
     def _create_feature_matrix(
         self,
-        features: Dict[Any, FeatureCollector],
-        features_main_keys: List[str],
-        node_to_index: Dict[Any, int],
-        shape: Tuple[int, int],
+        features: dict[Any, FeatureCollector],
+        features_main_keys: list[str],
+        node_to_index: dict[Any, int],
+        shape: tuple[int, int],
         dtype: type,
     ):
         """
@@ -110,12 +111,12 @@ class FeaturePass(GenericPass):
 
     def _compute_sim_matrix(
         self,
-        shape: Tuple[int, int],
-        primary_features: Dict[Any, FeatureCollector],
-        secondary_features: Dict[Any, FeatureCollector],
-        primary_mapping: Dict[Any, int],
-        secondary_mapping: Dict[Any, int],
-        features_main_keys: List[str],
+        shape: tuple[int, int],
+        primary_features: dict[Any, FeatureCollector],
+        secondary_features: dict[Any, FeatureCollector],
+        primary_mapping: dict[Any, int],
+        secondary_mapping: dict[Any, int],
+        features_main_keys: list[str],
         distance: str,
         dtype: type,
         weights: Iterable[float] | None = None,
@@ -200,8 +201,8 @@ class FeaturePass(GenericPass):
         sim_matrix: SimMatrix,
         primary: Program,
         secondary: Program,
-        primary_mapping: Dict[Any, int],
-        secondary_mapping: Dict[Any, int],
+        primary_mapping: dict[Any, int],
+        secondary_mapping: dict[Any, int],
         fill: bool = False,
     ) -> None:
         """

--- a/src/qbindiff/types.py
+++ b/src/qbindiff/types.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 
 from __future__ import annotations
-from typing import Any, Iterable, TypeAlias, List, Tuple, Dict
+from collections.abc import Iterable
+from typing import Any, TypeAlias
 
 import numpy
 from pathlib import Path
@@ -29,7 +30,7 @@ from qbindiff.abstract import GenericGraph
 """
 Type of a feature value.
 """
-FeatureValue: TypeAlias = float | Dict[str, float]
+FeatureValue: TypeAlias = float | dict[str, float]
 
 """
 Float greater than zero
@@ -59,12 +60,12 @@ Item: TypeAlias = Any
 """
 Pair of lists of user defined index correspondences. Default None.
 """
-Anchors: TypeAlias = List[Tuple[Item, Item]]
+Anchors: TypeAlias = list[tuple[Item, Item]]
 
 """
 Pair of lists of indexes that are mapped together.
 """
-RawMapping: TypeAlias = Tuple[List[Idx], List[Idx]]
+RawMapping: TypeAlias = tuple[list[Idx], list[Idx]]
 
 """
 Match represent the matching between two functions and can hold the similarity between the two
@@ -75,7 +76,7 @@ Match = namedtuple("Match", "primary secondary similarity confidence squares")
 """
 An extended version of RawMapping with two more lists recording pairing similarity and induced number of squares.
 """
-ExtendedMapping: TypeAlias = Iterable[Tuple[Item, Item, float, int]]
+ExtendedMapping: TypeAlias = Iterable[tuple[Item, Item, float, int]]
 
 """
 Numpy data type

--- a/src/qbindiff/visitor.py
+++ b/src/qbindiff/visitor.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 
 import tqdm
-from abc import ABCMeta, abstractmethod
 import logging
-from typing import Any, Callable, List, Dict
+from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
+from typing import Any
 
 from qbindiff.loader import Program, Function, BasicBlock, Instruction, Operand
 from qbindiff.features.extractor import (
@@ -40,7 +41,7 @@ class Visitor(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def feature_extractors(self) -> List[FeatureExtractor]:
+    def feature_extractors(self) -> list[FeatureExtractor]:
         """
         Returns the list of registered features extractor
         """
@@ -49,7 +50,7 @@ class Visitor(metaclass=ABCMeta):
 
     def visit(
         self, graph: Graph, key_fun: Callable = lambda _, i: i
-    ) -> Dict[Any, FeatureCollector]:
+    ) -> dict[Any, FeatureCollector]:
         """
         Function performing the visit on a Graph object by calling visit_item with a
         FeatureCollector meant to be filled.
@@ -99,12 +100,12 @@ class NoVisitor(Visitor):
     """
 
     @property
-    def feature_extractors(self) -> List[FeatureExtractor]:
+    def feature_extractors(self) -> list[FeatureExtractor]:
         return []
 
     def visit(
         self, graph: Graph, key_fun: Callable = lambda _, i: i
-    ) -> Dict[Any, FeatureCollector]:
+    ) -> dict[Any, FeatureCollector]:
         return {key_fun(item, i): FeatureCollector() for i, item in enumerate(graph.items())}
 
     def register_feature_extractor(self, fte: FeatureExtractor) -> None:


### PR DESCRIPTION
As stated in [PEP-585](https://peps.python.org/pep-0585/) since python 3.9 there is a new syntax for static typing. The old way will be supported until 2025 but later it could be removed. It makes sense to use directly the new syntax since it should also come with a (very small) performance boost.