### PR TITLE
Clean CLI help and code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,49 +89,39 @@ The complete command line options are:
 
     Usage: qbindiff [OPTIONS] <primary file> <secondary file>
 
-      qBinDiff is an experimental binary diffing tool based on machine learning technics, namely Belief propagation.
+      QBinDiff is an experimental binary diffing tool based on machine learning technics, namely Belief propagation.
 
     Options:
-      -l, --loader <loader>         Loader type to be used. Must be one of these ['binexport', 'qbinexport']. [default: binexport]
-      -f, --features <feature>      The following features are available:
-                                      - bnb: Number of basic blocks in the function
-                                      - meanins: Mean number of instructions per basic blocks in the function
-                                      - Gmd: Mean degree of the function
-                                      - Gd: Density of the function flow graph
-                                      - Gnc: Number of components in the function (non-connected flow graphs)
-                                      - Gdi: Diamater of the function flow graph
-                                      - Gt: Transitivity of the function flow graph
-                                      - Gcom: Number of graph communities (Louvain modularity)
-                                      - cnb: Number of children of the function
-                                      - pnb: Number of parents of the function
-                                      - rnb: Number of relatives of the function
-                                      - lib: Call to library functions (local function)
-                                      - dat: References to data in the instruction
-                                      - wlgk: Weisfeiler-Lehman Graph Kernel
-                                      - fname: Match the function names
-                                      - M: Mnemonic of instructions feature
-                                      - Mt: Mnemonic and type of operand feature
-                                      - Gp: Group of the instruction (FPU, SSE, stack..)
-                                      - addr: Address of the function as a feature
-                                      - dat: References to data in the instruction
-                                      - cst: Numeric constant (32/64bits) in the instruction (not addresses)
-                                    Features may be weighted by a positive value (default 1.0) and compared with a specificdistance (by default the option -d is used) like this <feature>:<weight>:<distance>
-                                    [default: ('bnb', 'meanins', 'Gmd', 'Gd', 'Gnc', 'Gdi', 'Gt', 'cnb', 'pnb', 'rnb', 'lib', 'dat', 'M', 'Mt', 'Gp', 'addr', 'dat', 'cst')]
-      -n, --normalize               Normalize the Call Graph (can potentially lead to a partial matching). [default disabled]
-      -d, --distance <function>     The following distances are available ('canberra', 'correlation', 'cosine', 'euclidean')
-                                    [default: canberra]
-      -s, --sparsity-ratio FLOAT    Ratio of least probable matches to ignore. Between 0.0 to 1.0 [default: 0.75]
-      -t, --tradeoff FLOAT          Tradeoff between function content (near 1.0) and call-graph information (near 0.0) [default: 0.75]
-      -e, --epsilon FLOAT           Relaxation parameter to enforce convergence [default: 0.50]
-      -i, --maxiter INTEGER         Maximum number of iteration for belief propagation [default: 1000]
-      -e1, --executable1 PATH       Path to the primary raw executable. Must be provided if using qbinexport loader
-      -e2, --executable2 PATH       Path to the secondary raw executable. Must be provided if using qbinexport loader
+      -l, --loader <loader>         Loader type to be used. Must be one of these ['binexport', 'quokka', 'ida']  [default:
+                                    binexport]
+      -f, --feature <feature>       Features to use for the binary analysis, it can be specified multiple times.
+                                    Features may be weighted by a positive value (default 1.0) and/or compared with a
+                                    specific distance (by default the option -d is used) like this <feature>:<weight>:<distance>.
+                                    For a list of all the features available see --list-features.
+      -n, --normalize               Normalize the Call Graph (can potentially lead to a partial matching). [default
+                                    disabled]
+      -d, --distance <function>     The following distances are available ['canberra', 'euclidean', 'cosine',
+                                    'jaccard_strong']  [default: canberra]
+      -s, --sparsity-ratio FLOAT    Ratio of least probable matches to ignore. Between 0.0 (nothing is ignored) to 1.0
+                                    (only perfect matches are considered)  [default: 0.75]
+      -sr, --sparse-row             Whether to build the sparse similarity matrix considering its entirety or processing
+                                    it row per row
+      -t, --tradeoff FLOAT          Tradeoff between function content (near 1.0) and call-graph information (near 0.0)
+                                    [default: 0.75]
+      -e, --epsilon FLOAT           Relaxation parameter to enforce convergence  [default: 0.5]
+      -i, --maxiter INTEGER         Maximum number of iteration for belief propagation  [default: 1000]
+      -e1, --executable1 PATH       Path to the primary raw executable. Must be provided if using quokka loader
+      -e2, --executable2 PATH       Path to the secondary raw executable. Must be provided if using quokka loader
       -o, --output PATH             Write output to PATH
-      -ff, --file-format [bindiff]  The file format of the output file. Supported formats are [bindiff]. [default: bindiff]
+      -ff, --file-format [bindiff]  The file format of the output file. Supported formats are [bindiff]  [default:
+                                    bindiff]
+      -v, --verbose                 Activate debugging messages. Can be supplied multiple times to increase verbosity
+      --version                     Show the version and exit.
       --enable-cortexm              Enable the usage of the cortex-m extension when disassembling
-      -v, --verbose                 Activate debugging messages
+      --list-features               List all the available features
+      --help-all                    Show the full help message, including all the options that affect the disassembly
+                                    phase
       -h, --help                    Show this message and exit.
-
 
 ## Library usage
 

--- a/bin/qbindiff
+++ b/bin/qbindiff
@@ -16,21 +16,24 @@ limitations under the License.
 """
 
 # builtin-imports
+from __future__ import annotations
 import logging
 import os
 from pathlib import Path
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 # Third-party imports
 import click
-import numpy as np
-from tqdm import tqdm
 
 # Local imports
+from qbindiff import __version__ as qbindiff_version
+from qbindiff import LoaderType, Program, QBinDiff, Mapping, Distance
+from qbindiff.loader import LOADERS
 from qbindiff.features import FEATURES, DEFAULT_FEATURES
-from qbindiff.loader import LOADERS, LoaderType
-from qbindiff import Program, QBinDiff, Mapping
-from qbindiff.types import Distance
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def configure_logging(verbose: int):
@@ -67,10 +70,10 @@ def display_statistics(differ: QBinDiff, mapping: Mapping) -> None:
 
 FEATURES_KEYS = {x.key: x for x in FEATURES}
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"], max_content_width=300)
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"], max_content_width=120)
 
 DEFAULT_FEATURES = tuple(x.key for x in DEFAULT_FEATURES)
-DEFAULT_DISTANCE = "canberra"
+DEFAULT_DISTANCE = Distance.canberra.name
 DEFAULT_SPARSITY_RATIO = 0.75
 DEFAULT_TRADEOFF = 0.75
 DEFAULT_EPSILON = 0.5
@@ -78,20 +81,32 @@ DEFAULT_MAXITER = 1000
 
 LOADERS_KEYS = list(LOADERS.keys())
 
-help_formats = (
-    f"The file format of the output file. Supported formats are [bindiff]. [default: bindiff]"
-)
-help_loaders = f"Loader type to be used. Must be one of these {LOADERS_KEYS}. [default: binexport]"
+
+def list_features(ctx: click.Context, param: click.Parameter, value: Any) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo("The following features are available:")
+    for feature in FEATURES:
+        click.echo(f"  - {feature.key}:")
+        click.echo(f"    {feature.help_msg}\n")
+    ctx.exit()
+
+
+def full_help(ctx: click.Context, param: click.Parameter, value: Any) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    for p in ctx.command.get_params(ctx):
+        if isinstance(p, click.Option) and p.hidden:
+            p.hidden = False
+    click.echo(ctx.get_help())
+    ctx.exit()
+
+
 help_features = """\b
-The following features are available:
-{}
-Features may be weighted by a positive value (default 1.0) and compared with a specificdistance (by default the option -d is used) like this <feature>:<weight>:<distance>
-[default: {}]""".format(
-    "\n".join("  - {}: {}".format(x.key, x.__doc__) for x in FEATURES), DEFAULT_FEATURES
-)
-help_distance = f"""\b
-The following distances are available {[d.name for d in Distance]}
-[default: canberra]"""
+Features to use for the binary analysis, it can be specified multiple times.
+Features may be weighted by a positive value (default 1.0) and/or compared with a
+specific distance (by default the option -d is used) like this <feature>:<weight>:<distance>.
+For a list of all the features available see --list-features."""
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -99,26 +114,20 @@ The following distances are available {[d.name for d in Distance]}
     "-l",
     "--loader",
     type=click.Choice(LOADERS_KEYS),
+    show_default=True,
     default="binexport",
     metavar="<loader>",
-    help=help_loaders,
+    help=f"Loader type to be used. Must be one of these {LOADERS_KEYS}",
 )
 @click.option(
     "-f",
-    "--features",
+    "--feature",
+    "features",
     type=str,
     default=DEFAULT_FEATURES,
     multiple=True,
     metavar="<feature>",
     help=help_features,
-)
-@click.option(
-    "-fopt",
-    "--feature-option",
-    type=(str, str, str),
-    multiple=True,
-    metavar="<feature> <option> <value>",
-    help="Specify a feature option. To get a list of options accepted by a feature look into the description of the feature",
 )
 @click.option(
     "-n",
@@ -129,18 +138,19 @@ The following distances are available {[d.name for d in Distance]}
 @click.option(
     "-d",
     "--distance",
-    type=click.Choice([d.name for d in Distance]),
+    type=click.Choice((d.name for d in Distance)),
+    show_default=True,
     default=DEFAULT_DISTANCE,
     metavar="<function>",
-    help=help_distance,
+    help=f"The following distances are available {[d.name for d in Distance]}",
 )
 @click.option(
     "-s",
     "--sparsity-ratio",
     type=float,
+    show_default=True,
     default=DEFAULT_SPARSITY_RATIO,
-    help="Ratio of least probable matches to ignore. Between 0.0 (nothing is ignored) to 1.0 (only perfect matches are considered) [default: %.02f]"
-    % DEFAULT_SPARSITY_RATIO,
+    help=f"Ratio of least probable matches to ignore. Between 0.0 (nothing is ignored) to 1.0 (only perfect matches are considered)",
 )
 @click.option(
     "-sr",
@@ -152,23 +162,25 @@ The following distances are available {[d.name for d in Distance]}
     "-t",
     "--tradeoff",
     type=float,
+    show_default=True,
     default=DEFAULT_TRADEOFF,
-    help="Tradeoff between function content (near 1.0) and call-graph information (near 0.0) [default: %.02f]"
-    % DEFAULT_TRADEOFF,
+    help=f"Tradeoff between function content (near 1.0) and call-graph information (near 0.0)",
 )
 @click.option(
     "-e",
     "--epsilon",
     type=float,
+    show_default=True,
     default=DEFAULT_EPSILON,
-    help="Relaxation parameter to enforce convergence [default: %.02f]" % DEFAULT_EPSILON,
+    help=f"Relaxation parameter to enforce convergence",
 )
 @click.option(
     "-i",
     "--maxiter",
     type=int,
+    show_default=True,
     default=DEFAULT_MAXITER,
-    help="Maximum number of iteration for belief propagation [default: %d]" % DEFAULT_MAXITER,
+    help=f"Maximum number of iteration for belief propagation",
 )
 @click.option(
     "-e1",
@@ -193,14 +205,10 @@ The following distances are available {[d.name for d in Distance]}
 @click.option(
     "-ff",
     "--file-format",
+    show_default=True,
     default="bindiff",
     type=click.Choice(["bindiff"]),
-    help=help_formats,
-)
-@click.option(
-    "--enable-cortexm",
-    is_flag=True,
-    help="Enable the usage of the cortex-m extension when disassembling",
+    help=f"The file format of the output file. Supported formats are [bindiff]",
 )
 @click.option(
     "-v",
@@ -208,12 +216,34 @@ The following distances are available {[d.name for d in Distance]}
     count=True,
     help="Activate debugging messages. Can be supplied multiple times to increase verbosity",
 )
+@click.version_option(qbindiff_version)
+@click.option(
+    "--enable-cortexm",
+    is_flag=True,
+    hidden=True,
+    help="Enable the usage of the cortex-m extension when disassembling",
+)
+@click.option(
+    "--list-features",
+    is_flag=True,
+    callback=list_features,
+    expose_value=False,
+    is_eager=True,
+    help="List all the available features",
+)
+@click.option(
+    "--help-all",
+    is_flag=True,
+    callback=full_help,
+    expose_value=False,
+    is_eager=True,
+    help="Show the full help message, including all the options that affect the disassembly phase",
+)
 @click.argument("primary", type=Path, metavar="<primary file>")
 @click.argument("secondary", type=Path, metavar="<secondary file>")
 def main(
     loader,
     features,
-    feature_option,
     normalize,
     distance,
     sparsity_ratio,
@@ -231,7 +261,7 @@ def main(
     secondary,
 ):
     """
-    qBinDiff is an experimental binary diffing tool based on
+    QBinDiff is an experimental binary diffing tool based on
     machine learning technics, namely Belief propagation.
     """
 
@@ -257,11 +287,6 @@ def main(
 
     if not output:
         logging.warning("[-] You have not specified an output file")
-
-    # Group options to pass to the feature extractors
-    feature_option_dict = defaultdict(dict)
-    for option in feature_option:
-        feature_option_dict[option[0]][option[1]] = option[2]
 
     loader = LOADERS[loader]
 
@@ -322,12 +347,7 @@ def main(
         extractor_class = FEATURES_KEYS[feature]
         if distance is not None:
             distance = Distance[distance]
-        feature_opts = {
-            k: extractor_class.options[k].parser(v) for k, v in feature_option_dict[feature].items()
-        }
-        qbindiff.register_feature_extractor(
-            extractor_class, float(weight), distance=distance, **feature_opts
-        )
+        qbindiff.register_feature_extractor(extractor_class, float(weight), distance=distance)
 
     logging.info("[+] Initializing NAP")
     qbindiff.process()

--- a/src/qbindiff/features/artefact.py
+++ b/src/qbindiff/features/artefact.py
@@ -58,6 +58,11 @@ class DatName(InstructionFeatureExtractor):
     """
 
     key = "dat"
+    help_msg = """
+    References to data in the instruction (as retrieved by the backend loader).
+    This feature maps the data value to the number of reference occurences to it.
+    It's a superset of StrRef (strref) feature.
+    """.strip()
 
     def visit_instruction(
         self, _: Program, instruction: Instruction, collector: FeatureCollector

--- a/src/qbindiff/features/extractor.py
+++ b/src/qbindiff/features/extractor.py
@@ -116,13 +116,21 @@ class FeatureCollector:
         return vector.tocsr()
 
 
-class FeatureExtractor:
+class FeatureExtractorMeta(type):
+    def __init__(cls, *args, **kwargs):
+        # Check if a local "help_msg" attribute has been defined in the class
+        if "help_msg" not in cls.__dict__:
+            cls.help_msg = cls.__doc__.strip()
+
+
+class FeatureExtractor(metaclass=FeatureExtractorMeta):
     """
     Base class that represent a feature extractor which sole contraints are to
     define a unique key and a function call that is to be called by the visitor.
     """
 
     key: str = ""  #: feature name (short)
+    help_msg: str = ""  #: CLI help message
 
     def __init__(self, weight: Positive = 1.0):
         """

--- a/src/qbindiff/features/graph.py
+++ b/src/qbindiff/features/graph.py
@@ -96,13 +96,18 @@ class CyclomaticComplexity(FunctionFeatureExtractor):
 
 class MDIndex(FunctionFeatureExtractor):
     """
-    MD-Index of the function,
-    based on `<https://www.sto.nato.int/publications/STO%20Meeting%20Proceedings/RTO-MP-IST-091/MP-IST-091-26.pdf>`_.
-    A slightly modified version of it : notice the topological sort is only available for DAG graphs
+    MD-Index of the function, based on
+    `<https://www.sto.nato.int/publications/STO%20Meeting%20Proceedings/RTO-MP-IST-091/MP-IST-091-26.pdf>`_.
+    A slightly modified version of it: notice the topological sort is only available for DAG graphs
     (which may not always be the case)
     """
 
     key = "mdidx"
+    help_msg = """
+    MD-Index of the function, based on https://www.sto.nato.int/publications/STO%20Meeting%20Proceedings/RTO-MP-IST-091/MP-IST-091-26.pdf.
+    A slightly modified version of it: notice the topological sort is only available for
+    DAG graphs (which may not always be the case)
+    """.strip()
 
     def visit_function(
         self, program: Program, function: Function, collector: FeatureCollector
@@ -167,6 +172,12 @@ class SmallPrimeNumbers(FunctionFeatureExtractor):
     """
 
     key = "spp"
+    help_msg = """
+    Small-Prime-Number based on mnemonics, as defined in Bindiff 
+    (see https://www.sto.nato.int/publications/STO%20Meeting%20Proceedings/RTO-MP-IST-091/MP-IST-091-26.pdf).
+    This hash is slightly different from the theoretical implementation. Modulo is made
+    at each round, instead of doing it at the end.
+    """.strip()
 
     @staticmethod
     def primesbelow(n: int) -> list[int]:

--- a/src/qbindiff/features/mnemonic.py
+++ b/src/qbindiff/features/mnemonic.py
@@ -68,6 +68,11 @@ class GroupsCategory(InstructionFeatureExtractor):
     """
 
     key = "Gp"
+    help_msg = """
+    Categorization of instructions feature.
+    It can correspond to instructions subset (XMM, AES etc..), or more generic grouping
+    like (arithmetic, comparisons etc..). As of now, rely on capstone groups.
+    """.strip()
 
     def visit_instruction(
         self, program: Program, instruction: Instruction, collector: FeatureCollector

--- a/src/qbindiff/loader/__init__.py
+++ b/src/qbindiff/loader/__init__.py
@@ -27,6 +27,7 @@ from qbindiff.loader.basic_block import BasicBlock
 from qbindiff.loader.function import Function
 from qbindiff.loader.program import Program
 from qbindiff.loader.types import LoaderType
+from qbindiff.types import Distance
 
 LOADERS = {
     "binexport": LoaderType.binexport,

--- a/src/qbindiff/loader/types.py
+++ b/src/qbindiff/loader/types.py
@@ -31,11 +31,10 @@ class LoaderType(IntEnum):
     Enum of different loaders (supported or not)
     """
 
-    unknown = 0  # doc: unknown loader
-    binexport = 1  # doc: binexport loader
-    diaphora = 2  # doc: diaphora loader (not supported)
-    ida = 3  # doc: IDA loader
-    quokka = 4  # doc: Quokka loader
+    binexport = 0  # doc: binexport loader
+    diaphora = 1  # doc: diaphora loader (not supported)
+    ida = 2  # doc: IDA loader
+    quokka = 3  # doc: Quokka loader
 
 
 @enum_tools.documentation.document_enum


### PR DESCRIPTION
The help message was broken, this PR should fix it and clean it by grouping the different options.

All the options associated to the disassembly phase (for now it's only `--enable-cortexm` but in future there will be more for arm and mips modes) are hidden by default to avoid littering the help. They can be shown with `--help-all`

All the features available are hidden by default and can be shown with `--list-features`

There are other small fixes:
  - Remove `LoaderType.unknown` as there cannot be a unknown loader
  - Import `Distance` from `__init__.py`