### PR TITLE
Add tests in the CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,30 @@
+name: Build_Test
+
+on:
+  - push
+  - pull_request
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - ["3.10", "py310"]
+          - ["3.11", "py311"]
+          - ["3.12", "py312"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version[0] }}
+
+      - name: Install tox
+        run: python -m pip install tox
+
+      - name: Build and test
+        run: tox -e ${{ matrix.python-version[1] }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,7 +15,6 @@ jobs:
         python-version:
           - ["3.10", "py310"]
           - ["3.11", "py311"]
-          - ["3.12", "py312"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,9 +17,9 @@ jobs:
           - ["3.11", "py311"]
           - ["3.12", "py312"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version[0] }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -41,7 +41,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse-${{ matrix.os }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheelhouse-${{ matrix.os }}
           path: ./wheelhouse-${{ matrix.os }}/*.whl
@@ -49,9 +49,9 @@ jobs:
   build_sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -60,7 +60,7 @@ jobs:
           python -m pip install -U pip build
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: ./dist/*
@@ -72,7 +72,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # By omitting the name we are downloading all the artifacts
           path: ./dist/


### PR DESCRIPTION
This will add a CI for testing at each commit on main branch and each PR.
The CI will run the tests on all the supported python versions (3.12 is not yet supported because capstone doesn't yet support it)