### PR TITLE
Allow empty feature vectors and better define haussmann distance

### DIFF
--- a/doc/source/params.rst
+++ b/doc/source/params.rst
@@ -34,7 +34,11 @@ Haussmann
 Formally it is defined as:
 
 .. math::
-   d(u, v) = \sum_{i=0}^n\frac{f(u_i, v_i)}{ \lvert \{ j | u_j \neq 0 \lor v_j \neq 0 \} \rvert }
+   d(u, v) = 
+   \begin{cases}
+    0 & \text{if } \forall i \; u_i = 0 \and v_i = 0 \\
+    1 - \sum_{i=0}^n\frac{f(u_i, v_i)}{ \lvert \{ j | u_j \neq 0 \lor v_j \neq 0 \} \rvert } & text{otherwise}
+   \end{cases}
 
 .. math::
    with\ u, v \in \mathbb{R}^n

--- a/doc/source/params.rst
+++ b/doc/source/params.rst
@@ -36,8 +36,8 @@ Formally it is defined as:
 .. math::
    d(u, v) = 
    \begin{cases}
-    0 & \text{if } \forall i \; u_i = 0 \and v_i = 0 \\
-    1 - \sum_{i=0}^n\frac{f(u_i, v_i)}{ \lvert \{ j | u_j \neq 0 \lor v_j \neq 0 \} \rvert } & text{otherwise}
+    0 & \text{if } \forall i \; u_i = 0 \land v_i = 0 \\
+    1 - \sum_{i=0}^n\frac{f(u_i, v_i)}{ \lvert \{ j | u_j \neq 0 \lor v_j \neq 0 \} \rvert } & \text{otherwise}
    \end{cases}
 
 .. math::

--- a/src/qbindiff/features/extractor.py
+++ b/src/qbindiff/features/extractor.py
@@ -68,13 +68,10 @@ class FeatureCollector:
         """
         self._features.setdefault(key, defaultdict(float))
 
-        if value == {}:
-            FeatureKeyManager.add(key)
-            self._features[key] = 0
-        else:
-            for k, v in value.items():
-                FeatureKeyManager.add(key, k)
-                self._features[key][k] += v
+        FeatureKeyManager.add(key)
+        for k, v in value.items():
+            FeatureKeyManager.add(key, k)
+            self._features[key][k] += v
 
     def feature_vector(self) -> None:
         """Show the feature vector associated to the node"""

--- a/src/qbindiff/features/manager.py
+++ b/src/qbindiff/features/manager.py
@@ -31,7 +31,8 @@ class FeatureKeyManagerClass:
         Add the main_key and optionally the sub_key to the key manager.
         """
 
-        self.mainkeys[main_key] = len(self.mainkeys)
+        # Do not update the values if they are already set
+        self.mainkeys.setdefault(main_key, len(self.mainkeys))
         self.subkeys.setdefault(main_key, {})
         if sub_key and sub_key not in self.subkeys[main_key]:
             self.subkeys[main_key][sub_key] = len(self.subkeys[main_key])

--- a/src/qbindiff/passes/base.py
+++ b/src/qbindiff/passes/base.py
@@ -185,8 +185,8 @@ class FeaturePass:
             ).astype(dtype)
 
         logging.debug("Distance calculated")
-        # Normalize
-        if len(sim_matrix) > 0 and sim_matrix.max() != 0:
+        # Normalize. Haussmann distance comes already normalized
+        if distance != Distance.haussmann and len(sim_matrix) > 0 and sim_matrix.max() != 0:
             sim_matrix /= sim_matrix.max()
         sim_matrix[:] = 1 - sim_matrix
 

--- a/src/qbindiff/passes/fast_metrics.pyx
+++ b/src/qbindiff/passes/fast_metrics.pyx
@@ -51,7 +51,7 @@ def sparse_canberra(floating[::1] X_data, int[:] X_indices, int[:] X_indptr,
     """Pairwise canberra distances for CSR matrices"""
     cdef cnp.npy_intp px, py, i, j, ix, iy
     cdef double d = 0.0
-    cdef double tmp;
+    cdef double tmp
 
     cdef int m = D.shape[0]
     cdef int n = D.shape[1]
@@ -127,10 +127,10 @@ def sparse_canberra(floating[::1] X_data, int[:] X_indices, int[:] X_indptr,
 def sparse_haussmann(floating[::1] X_data, int[:] X_indices, int[:] X_indptr,
                     floating[::1] Y_data, int[:] Y_indices, int[:] Y_indptr,
                     double[:, ::1] D, double[:] w):
-    """Pairwise canberra distances for CSR matrices"""
+    """Pairwise haussmann distances for CSR matrices"""
     cdef cnp.npy_intp px, py, i, j, ix, iy
     cdef double d = 0.0
-    cdef double tmp;
+    cdef double tmp
 
     cdef int m = D.shape[0]
     cdef int n = D.shape[1]
@@ -138,7 +138,7 @@ def sparse_haussmann(floating[::1] X_data, int[:] X_indices, int[:] X_indptr,
     cdef int X_indptr_end = 0
     cdef int Y_indptr_end = 0
     
-    cdef int Z = 0;
+    cdef int Z = 0
 
     cdef int num_threads = _openmp_effective_n_threads()
 

--- a/src/qbindiff/passes/metrics.py
+++ b/src/qbindiff/passes/metrics.py
@@ -115,7 +115,7 @@ def haussmann(X, Y, w=None):
 
     .. math::
 
-        \begin{cases} 0 & \text{if } \forall i \; u_i = 0 \and v_i = 0 \\ 1 - \sum_{i}\frac{f(u_i, v_i)}{ | \{ j | u_j \neq 0 \lor v_j \neq 0 \} | } & \text{otherwise.} \end{cases}
+        \begin{cases} 0 & \text{if } \forall i \; u_i = 0 \land v_i = 0 \\ 1 - \sum_{i}\frac{f(u_i, v_i)}{ | \{ j | u_j \neq 0 \lor v_j \neq 0 \} | } & \text{otherwise.} \end{cases}
 
     where the function ``f`` is defined like this:
 
@@ -127,7 +127,7 @@ def haussmann(X, Y, w=None):
 
     .. math::
 
-        \begin{cases} 0 & \text{if } \forall i \; u_i = 0 \and v_i = 0 \\ 1 - \sum_{i}\frac{w_i * f(u_i, v_i)}{ | \{ j | u_j \neq 0 \lor v_j \neq 0 \} | } & \text{otherwise.} \end{cases}
+        \begin{cases} 0 & \text{if } \forall i \; u_i = 0 \land v_i = 0 \\ 1 - \sum_{i}\frac{w_i * f(u_i, v_i)}{ | \{ j | u_j \neq 0 \lor v_j \neq 0 \} | } & \text{otherwise.} \end{cases}
 
     :param X: array-like of shape (n_samples_X, n_features)
               An array where each row is a sample and each column is a feature.

--- a/src/qbindiff/passes/metrics.py
+++ b/src/qbindiff/passes/metrics.py
@@ -115,7 +115,7 @@ def haussmann(X, Y, w=None):
 
     .. math::
 
-        \sum_{i}\frac{f(u_i, v_i)}{ | \{ j | u_j \neq 0 \lor v_j \neq 0 \} | }
+        \begin{cases} 0 & \text{if } \forall i \; u_i = 0 \and v_i = 0 \\ 1 - \sum_{i}\frac{f(u_i, v_i)}{ | \{ j | u_j \neq 0 \lor v_j \neq 0 \} | } & \text{otherwise.} \end{cases}
 
     where the function ``f`` is defined like this:
 
@@ -127,7 +127,7 @@ def haussmann(X, Y, w=None):
 
     .. math::
 
-        \sum_{i}\frac{w_i * f(u_i, v_i)}{ | \{ j | u_j \neq 0 \lor v_j \neq 0 \} | }
+        \begin{cases} 0 & \text{if } \forall i \; u_i = 0 \and v_i = 0 \\ 1 - \sum_{i}\frac{w_i * f(u_i, v_i)}{ | \{ j | u_j \neq 0 \lor v_j \neq 0 \} | } & \text{otherwise.} \end{cases}
 
     :param X: array-like of shape (n_samples_X, n_features)
               An array where each row is a sample and each column is a feature.


### PR DESCRIPTION
By allowing empty feature vectors some distances might end up with a division by zero, hence they will not work. This happens for example with the canberra distance when both vectors are null in some indices.
In such a case we suggest using the haussmann distance that can correctly handle all those cases.