### PR TITLE
Update build dependency numpy>=2.0 and use hot-fix lapjv-numpy2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,5 @@
 [build-system]
-requires = [
-    "meson-python>=0.7.0",
-    "meson>=1.1.0",
-    "cython",
-
-    # use oldest-supported-numpy which provides the oldest numpy version with
-    # wheels on PyPI
-    #
-    # see: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
-    "oldest-supported-numpy",
-]
+requires = ["meson-python>=0.7.0", "meson>=1.1.0", "cython", "numpy>=2.0"]
 build-backend = "mesonpy"
 
 [project]
@@ -23,7 +13,11 @@ dependencies = [
     "rich-click",
     "numpy",
     "scipy",
-    "lapjv",
+
+    # Current hot-fix for supporting numpy 2.x until https://github.com/src-d/lapjv/pull/85 is merged
+    "lapjv-numpy2",
+    # "lapjv>=1.35",
+
     "networkx",
     "capstone>=5.0.1",
     "datasketch",


### PR DESCRIPTION
Stop relying on the old scipy script to find the oldest numpy release (that will forbid compatibility with numpy 2.x), instead use the build time dependency numpy>=2.0 that is compatible with both numpy 1.x and 2.x

At the moment the only issue is represented by `lapjv` that is still relying on numpy 1.x at build time. Until https://github.com/src-d/lapjv/pull/85 will be merged and a new version will be released switch to a hot-fix that is numpy 2.x compatible: [lapjv-numpy2](https://pypi.org/project/lapjv-numpy2/).

See https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice for more information.
