### PR TITLE
Fix conversion from int to EnumType to be py3.10+ compatible

### DIFF
--- a/src/qbindiff/loader/types.py
+++ b/src/qbindiff/loader/types.py
@@ -130,22 +130,23 @@ class InstructionGroup(IntEnum):
     def fromint(cls, value: int):
         """Cast an integer to InstructionGroup type"""
         # Return an invalid group if cast is not possible
-        return (
-            InstructionGroup(value) if value in InstructionGroup else InstructionGroup.GRP_INVALID
-        )
+        try:
+            return InstructionGroup(value)
+        except ValueError:
+            return InstructionGroup.GRP_INVALID
 
     @classmethod
     def from_capstone(cls, capstone_group: int):
         """Cast a capstone group to InstructionGroup type"""
         # Wrap capstone group using our custom type
         # Note: This only works because the mappings between the enums are the same
-        if capstone_group in InstructionGroup:
+        try:
             return InstructionGroup(capstone_group)
-
-        # Raise an exception if cast is not possible
-        raise ValueError(
-            f"Misalignment between capstone group {capstone_group} and InstructionGroup"
-        )
+        except ValueError:
+            # Raise an exception if cast is not possible
+            raise ValueError(
+                f"Misalignment between capstone group {capstone_group} and InstructionGroup"
+            )
 
 
 @enum_tools.documentation.document_enum


### PR DESCRIPTION
the `in` operator from `int` to `EnumType` is supported only in python 3.12+ (see reference [https://docs.python.org/3/library/enum.html#enum.EnumType.__contains__](https://docs.python.org/3/library/enum.html#enum.EnumType.__contains__))