### PR TITLE
Mac support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ dependencies = [
     "scipy",
 
     # Current hot-fix for supporting numpy 2.x until https://github.com/src-d/lapjv/pull/85 is merged
-    "lapjv-numpy2",
     # "lapjv>=1.35",
+    # lapjv only supports Windows/Linux
+    "lapjv-numpy2; sys_platform == 'linux' or sys_platform == 'windows'",
+    "lapx; sys_platform != 'linux' and sys_platform != 'windows'",
 
     "networkx",
     "capstone>=5.0.1",

--- a/src/qbindiff/matcher/matcher.py
+++ b/src/qbindiff/matcher/matcher.py
@@ -22,12 +22,12 @@ from typing import TYPE_CHECKING
 
 # Third-party imports
 import numpy as np
-from lapjv import lapjv  # type: ignore[import-not-found]
 from scipy.sparse import csr_matrix, coo_matrix  # type: ignore[import-untyped]
 
 # Local imports
 from qbindiff.matcher.squares import find_squares  # type: ignore[import-untyped]
 from qbindiff.matcher.belief_propagation import BeliefMWM, BeliefQAP
+from qbindiff.utils import lap
 
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ def solve_linear_assignment(cost_matrix: Matrix) -> RawMapping:
         cost_matrix = cost_matrix.T
     full_cost_matrix = np.zeros((m, m), dtype=cost_matrix.dtype)
     full_cost_matrix[:n, :m] = cost_matrix
-    col_indices = lapjv(full_cost_matrix)[0][:n]
+    col_indices = lap(full_cost_matrix)[:n]
     if transposed:
         return col_indices, np.arange(n)
     return np.arange(n), col_indices

--- a/src/qbindiff/utils/__init__.py
+++ b/src/qbindiff/utils/__init__.py
@@ -17,4 +17,4 @@
 Collection of utilities used internally.
 """
 
-from .utils import is_debug, iter_csr_matrix, log_once, wrapper_iter
+from .utils import is_debug, iter_csr_matrix, lap, log_once, wrapper_iter

--- a/src/qbindiff/utils/utils.py
+++ b/src/qbindiff/utils/utils.py
@@ -23,10 +23,17 @@ from collections.abc import Iterator
 import logging
 from typing import TYPE_CHECKING
 
+try:
+    from lapjv import lapjv as _lap # type: ignore[import-not-found]
+    _is_lapjv = True
+except ImportError:
+    from lap import lapjv as _lap
+    _is_lapjv = False
+
 if TYPE_CHECKING:
     from collections.abc import Generator
     from typing import Any
-    from qbindiff.types import SparseMatrix
+    from qbindiff.types import Matrix, RawMapping, SparseMatrix
 
 
 def is_debug() -> bool:
@@ -47,6 +54,15 @@ def iter_csr_matrix(matrix: SparseMatrix) -> Generator[tuple[int, int, Any], Non
     coo_matrix = matrix.tocoo()
     for x, y, v in zip(coo_matrix.row, coo_matrix.col, coo_matrix.data):
         yield (x, y, v)
+
+
+def lap(cost_matrix: Matrix) -> RawMapping:
+    if _is_lapjv:
+        row_ind_lapjv, _col_ind_lapjv, _ = _lap(cost_matrix)
+        return row_ind_lapjv
+    else:
+        _cost, x, _y = _lap(cost_matrix)
+        return x
 
 
 @cache


### PR DESCRIPTION
Hi guys,

as pointed out on Twitter, **amazing stuff**.

This is me trying to add Mac support. Problem being `lapjv` doesn't work on Mac and I'd rather fix things on the python side than figuring out Cpp builds. It also seems like `lapjv` was never compiled on non-x86 as it pulls  `immintrin.h` at the top level.

So yeah, I pulled in `lapx` and this is what I get for tests on py312:

```
% uv tool run tox run -e py312
.pkg: _optional_hooks> python /Users/ciao/.cache/uv/archive-v0/-gLQxuIFvlfE9VPhZaeST/lib/python3.12/site-packages/pyproject_api/_backend.py True mesonpy
.pkg: get_requires_for_build_wheel> python /Users/ciao/.cache/uv/archive-v0/-gLQxuIFvlfE9VPhZaeST/lib/python3.12/site-packages/pyproject_api/_backend.py True mesonpy
.pkg: build_wheel> python /Users/ciao/.cache/uv/archive-v0/-gLQxuIFvlfE9VPhZaeST/lib/python3.12/site-packages/pyproject_api/_backend.py True mesonpy
py312: install_package> python -I -m pip install --force-reinstall --no-deps /Users/ciao/src/qbindiff/.tox/.tmp/package/16/qbindiff-1.2.2-cp312-cp312-macosx_15_0_arm64.whl
py312: commands[0]> pytest --color=yes
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.12.7, pytest-8.3.3, pluggy-1.5.0
cachedir: .tox/py312/.pytest_cache
rootdir: /Users/ciao/src/qbindiff
configfile: pyproject.toml
collected 16 items

tests/test_binary.py ..                                                                                                                                                     [ 12%]
tests/test_graph.py ...                                                                                                                                                     [ 31%]
tests/test_sparse_matrix.py ........                                                                                                                                        [ 81%]
tests/test_squares.py ...                                                                                                                                                   [100%]

=============================================================================== 16 passed in 45.42s ===============================================================================
.pkg: _exit> python /Users/ciao/.cache/uv/archive-v0/-gLQxuIFvlfE9VPhZaeST/lib/python3.12/site-packages/pyproject_api/_backend.py True mesonpy
  py312: OK (50.08=setup[4.50]+cmd[45.59] seconds)
  congratulations :) (50.11 seconds)
```

**Hopefully** your tests would **catch a problem** in my commits? 😬 
I'm open to trying out more stuff (now I'm moving to actually trying out qbindiff).

Performance-wise I have no idea how `lapx` compares to `lapjv`, but from a quick look at the code `lapx` isn't doing any fancy optimization.

**Side note:** `matcher.py` mentions `col_indices` but `lapjv` calls the same return value `row_ind_lapjv`. I didn't rename in the outer function, but that looks weird to my monkey brain.