### PR TITLE
Update qbindiff (export_path) and failsafe InstructionGroup

### DIFF
--- a/src/qbindiff/__main__.py
+++ b/src/qbindiff/__main__.py
@@ -233,6 +233,7 @@ For a list of all the features available see --list-features."""
     default=DEFAULT_FEATURES,
     multiple=True,
     metavar="<feature>",
+    show_default=True,
     help=help_features,
 )
 @click.option(
@@ -420,6 +421,11 @@ def main(
         )
         return 1
 
+    if not features:
+        logging.error("no feature provided")
+        return 1
+
+
     with Progress() as progress:
         if not quiet:
             load_bar_total = 2
@@ -454,10 +460,6 @@ def main(
             )
         except Exception as e:
             logging.error(e)
-            exit(1)
-
-        if not features:
-            logging.error("no feature provided")
             exit(1)
 
         try:

--- a/src/qbindiff/loader/backend/abstract.py
+++ b/src/qbindiff/loader/backend/abstract.py
@@ -321,6 +321,15 @@ class AbstractProgramBackend(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @property
+    @abstractmethod
+    def export_path(self) -> str:
+        """
+        Returns the export file path (if any).
+        Empty string if not export file
+        """
+        raise NotImplementedError()
+
+    @property
     def capabilities(self) -> ProgramCapability:
         """
         Returns the supported capabilities

--- a/src/qbindiff/loader/backend/binexport.py
+++ b/src/qbindiff/loader/backend/binexport.py
@@ -497,6 +497,13 @@ class ProgramBackendBinExport(AbstractProgramBackend):
         return self.name.replace(".BinExport", "")  # Try to guess it as best effort
 
     @property
+    def export_path(self) -> str:
+        """
+        Returns the .Binexport path
+        """
+        return str(self.be_prog.path)
+
+    @property
     def capabilities(self) -> ProgramCapability:
         """
         Returns the supported capabilities

--- a/src/qbindiff/loader/backend/ida.py
+++ b/src/qbindiff/loader/backend/ida.py
@@ -514,3 +514,10 @@ class ProgramBackendIDA(AbstractProgramBackend):
         """
 
         return ida_nalt.get_input_file_path()
+
+    @property
+    def export_path(self) -> str:
+        """
+        Returns empty string as IDA does not have exports
+        """
+        return ""

--- a/src/qbindiff/loader/backend/quokka.py
+++ b/src/qbindiff/loader/backend/quokka.py
@@ -609,8 +609,14 @@ class ProgramBackendQuokka(AbstractProgramBackend):
         """
         Returns the executable path
         """
-
         return self._exec_path
+
+    @property
+    def export_path(self) -> str:
+        """
+        Returns the Quokka export path
+        """
+        return str(self.qb_prog.export_file)
 
     @property
     def capabilities(self) -> ProgramCapability:

--- a/src/qbindiff/loader/program.py
+++ b/src/qbindiff/loader/program.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING
 from pathlib import Path
+import logging
 
 from qbindiff.abstract import GenericGraph
 from qbindiff.loader import Function
@@ -254,6 +255,14 @@ class Program(MutableMapping, GenericGraph):
         """
 
         return self._backend.exec_path
+
+    @property
+    def export_path(self) -> str | None:
+        """
+        The exported file path if it has been specified, None otherwise
+        """
+        exp = self._backend.export_path
+        return exp if exp else None
 
     def set_function_filter(self, func: Callable[[Addr], bool]) -> None:
         """

--- a/src/qbindiff/loader/types.py
+++ b/src/qbindiff/loader/types.py
@@ -16,9 +16,13 @@
 """
 
 from __future__ import annotations
+
+import logging
 from enum import IntEnum, IntFlag, auto
 from typing import TypeAlias, TYPE_CHECKING
 import enum_tools.documentation
+
+from qbindiff.utils import log_once
 
 if TYPE_CHECKING:
     from qbindiff.loader.data import Data
@@ -143,10 +147,11 @@ class InstructionGroup(IntEnum):
         try:
             return InstructionGroup(capstone_group)
         except ValueError:
-            # Raise an exception if cast is not possible
-            raise ValueError(
-                f"Misalignment between capstone group {capstone_group} and InstructionGroup"
+            # Log once the unsupported
+            log_once(logging.WARN,
+                     f"Misalignment between capstone group {capstone_group} and InstructionGroup"
             )
+            return InstructionGroup.GRP_INVALID
 
 
 @enum_tools.documentation.document_enum

--- a/src/qbindiff/mapping/bindiff.py
+++ b/src/qbindiff/mapping/bindiff.py
@@ -164,8 +164,8 @@ def export_to_bindiff(
 
     binfile = BindiffFile.create(
         filename,
-        primary.exec_path,
-        secondary.exec_path,
+        primary.export_path,
+        secondary.export_path,
         f"Qbindiff {__version__}",
         "",
         mapping.normalized_similarity,


### PR DESCRIPTION
The following MR contains the following updates:

* add a ``export_path`` attribute for the Program object *(use for BindiffFile generation)*
* show defaults features (on the command line help)
* change ``InstructionGroup`` class not to raise exception when a capstone group is not supported (print a warning instead)