### PR TITLE
update .BinDiff file creation to comply with new API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "scikit-learn",
     "python-louvain",
     "enum_tools",
-    "python-bindiff",
+    "python-bindiff>=0.3.1",
     "python-binexport>=0.3.2",
     "quokka-project",
     "idascript",


### PR DESCRIPTION
Currently Bindiff file generated by Qbindiff are valid and can be opened in Bindiff UI, but they cannot be loaded in the IDA Pro plugin. As such, one can't port symbols!

This pull request in combination with a pull request in python-bindiff: https://github.com/quarkslab/python-bindiff/pull/11
enables generated fully valid .Bindiff files that can be opened in the IDA Pro plugin to port symbols.
